### PR TITLE
chore: replace instance groups when k8s version changes

### DIFF
--- a/internal/controller/cluster/kops_helpers.go
+++ b/internal/controller/cluster/kops_helpers.go
@@ -99,6 +99,13 @@ func (k *kopsClient) diffClusterV2(_ context.Context, cr *apisv1alpha1.Cluster) 
 	clusterYaml, igYamls := buildKopsYamlStructs(cr)
 	changes := []observedDelta{}
 
+	clusterChanged := false
+	//  Detect if kubernetesVersion changed at the cluster level. When it does,
+	// instance groups must also be included in the update so that kops
+	// regenerates their nodeupconfig.yaml in S3 with the new version.
+	kubernetesVersionChanged := cr.Status.AtProvider.ClusterSpec != nil &&
+		cr.Status.AtProvider.ClusterSpec.KubernetesVersion != clusterYaml.Spec.KubernetesVersion
+
 	if !cmp.Equal(cr.Status.AtProvider.ClusterSpec, &clusterYaml.Spec) {
 		diff := cmp.Diff(cr.Status.AtProvider.ClusterSpec, &clusterYaml.Spec)
 		changes = append(changes, observedDelta{
@@ -107,6 +114,7 @@ func (k *kopsClient) diffClusterV2(_ context.Context, cr *apisv1alpha1.Cluster) 
 			ResourceFilePath: getKopsClusterFilename(cr, fileSuffix),
 			Diff:             diff,
 		})
+		clusterChanged = true
 	}
 
 	for _, igDesired := range igYamls {
@@ -125,6 +133,15 @@ func (k *kopsClient) diffClusterV2(_ context.Context, cr *apisv1alpha1.Cluster) 
 				Resource:         instanceGroupResourceDelta,
 				ResourceFilePath: getKopsInstanceGroupFilenameFromYaml(cr, &igDesired, fileSuffix),
 				Diff:             diff,
+			})
+		} else if clusterChanged && kubernetesVersionChanged {
+			// Append instance groups to changes when kubernetesVersion
+			// changed so that kops regenerates nodeupconfig.yaml for each IG
+			changes = append(changes, observedDelta {
+				Operation:		  updateDelta,
+				Resource:		  instanceGroupResourceDelta,
+				ResourceFilePath: getKopsInstanceGroupFilenameFromYaml(cr, &igDesired, fileSuffix),
+				Diff:			  fmt.Sprintf("cluster kubernetesVersion changed from %s to %s, including instance group in update", cr.Status.AtProvider.ClusterSpec.KubernetesVersion, clusterYaml.Spec.KubernetesVersion),
 			})
 		}
 	}


### PR DESCRIPTION
### Description of your changes

When upgrading k8s versions, the control plane instance groups are updated with the new k8s version. The node instance groups do not. 

This change will add the instance groups to `changes` to ensure they are upgraded when the k8s version has been changed.