### PR TITLE
fix: adding 2nd pass for kops update and rolling-update

### DIFF
--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -510,6 +510,15 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 			log.Info(fmt.Sprintf("UPDATE ERROR: %s; %+v", err.Error(), err))
 		} else if err := c.service.rollingUpdateCluster(bgCtx, cr); err != nil {
 			log.Info(fmt.Sprintf("ROLLING UPDATE ERROR: %s; %+v", err.Error(), err))
+		} else {
+			// Pass 2: after control-plane is rolled, kops may have pending changes
+			// for worker instance groups (e.g. version skew policy holds back worker
+			// nodeupconfig generation until control-plane is running the new version).
+			if err := c.service.kopsUpdateCluster(bgCtx, cr); err != nil {
+				log.Info(fmt.Sprintf("UPDATE ERROR (pass 2): %s; %+v", err.Error(), err))
+			} else if err := c.service.rollingUpdateCluster(bgCtx, cr); err != nil {
+				log.Info(fmt.Sprintf("ROLLING UPDATE ERROR (pass 2): %s; %+v", err.Error(), err))
+			}
 		}
 
 		if err := c.unlockCluster(bgCtx, cr, []string{providerKopsUpdateLocked}); err != nil {


### PR DESCRIPTION
### Description of your changes

When `kubernetesVersion` changes, kops 1.31+ enforces a version skew policy, only updating worker instance groups after the control-plane is confirmed running the new version. Previously, the provider ran a single `kops update cluster --yes` and `kops rolling-update cluster --yes` pass, which no longer updates all instance groups for kops 1.31+.

This change adds a second pass of `kops update cluster --yes` and `kops rolling-update cluster --yes` after the control-plane has been rolled, allowing kops to generate and apply the pending worker IG changes.

Ref:

https://kops.sigs.k8s.io/tutorial/upgrading-kubernetes/#note-for-kubernetes-131
