### PR TITLE
fix: use kubectl sanity check for cluster auth

### DIFF
--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -265,6 +265,15 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 				return mo, err
 			}
 		}
+		// now run kubectl sanity check w/ fallback for authentication to the cluster
+		_, err = c.service.getNamespacesViaKubectl(ctx, cr)
+		if err != nil {
+			log.Info(fmt.Sprintf("Kubectl client errors for %s: %s; likely authentication issue, reissuing client credentials", cr.Name, err.Error()))
+			if err := c.service.kopsExportKubecfgAdmin(ctx, cr, []string{}); err != nil {
+				mo.ResourceUpToDate = false
+				return mo, err
+			}
+		}
 
 		if len(output.Failures) == 0 && err == nil {
 			cr.Status.Status = apisv1alpha1.Ready

--- a/internal/controller/cluster/kops_helpers.go
+++ b/internal/controller/cluster/kops_helpers.go
@@ -540,6 +540,31 @@ func (k *kopsClient) rollingUpdateCluster(ctx context.Context, cr *apisv1alpha1.
 	return nil
 }
 
+// getNamespacesViaKubectl runs the kubectl cli command to get the namespaces in a kops cluster, we use this
+// as a sanity check to validate that the cluster is reachable and that the kubeconfig is valid.
+func (k *kopsClient) getNamespacesViaKubectl(ctx context.Context, cr *apisv1alpha1.Cluster) ([]byte, error) {
+
+	var stdOut, stdErr bytes.Buffer
+
+	//nolint:gosec
+	cmd := exec.CommandContext(
+		ctx,
+		"kubectl",
+		"get",
+		"namespaces",
+	)
+	cmd.Env = append(cmd.Env, getKopsCliEnv(cr, k)...)
+	log.Info(fmt.Sprintf("run: %s", cmd.String()))
+
+	cmd.Stdout = &stdOut
+	cmd.Stderr = &stdErr
+
+	if err := cmd.Run(); err != nil {
+		return []byte{}, errors.Wrapf(err, "cmd: %s; stderr: %s; stdout: %s", cmd.String(), stdErr.String(), stdOut.String())
+	}
+	return stdOut.Bytes(), nil
+}
+
 func (k *kopsClient) forceKubecfgSNI(ctx context.Context, cr *apisv1alpha1.Cluster) error {
 
 	// overwrite the tls server name to force usage of the kops api dns


### PR DESCRIPTION
Kube auth is timing out after 18hrs due to a behavioral change in the `kops validate cluster` command, it seems that this command no longer triggers an authentication error when the local kubeconfig auth expires, we're adding a sanity validation check via `kubectl get namespaces` to ensure re-authentication when the auth expires.