### PR TITLE
chore: kops@1.33.2

### DIFF
--- a/cluster/images/provider-kops/Makefile
+++ b/cluster/images/provider-kops/Makefile
@@ -11,7 +11,7 @@ include ../../../build/makelib/imagelight.mk
 # ====================================================================================
 # Targets
 
-KOPS_VERSION    := v1.33.0
+KOPS_VERSION    := v1.33.2
 KUBECTL_VERSION := v1.33.13
 
 img.build:


### PR DESCRIPTION

### Description of your changes

kops 1.33.0 made a change to coredns that is preventing pod scheduling due to spread constraints.

kops 1.33.1+ fixes this bug 

https://github.com/kubernetes/kops/pull/17554
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
