### PR TITLE
chore: kops@1.34.2

### DIFF
--- a/cluster/images/provider-kops/Makefile
+++ b/cluster/images/provider-kops/Makefile
@@ -11,8 +11,8 @@ include ../../../build/makelib/imagelight.mk
 # ====================================================================================
 # Targets
 
-KOPS_VERSION    := v1.33.2
-KUBECTL_VERSION := v1.33.13
+KOPS_VERSION    := v1.34.2
+KUBECTL_VERSION := v1.34.9
 
 img.build:
 	@$(INFO) docker build $(IMAGE)


### PR DESCRIPTION
### Description of your changes

Upgrades provider versions for kops and kubectl to support k8s 1.34

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

