### PR TITLE
fix: set v1alpha1.ProviderConfigUsageGroupVersionKind

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -35,6 +35,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	of := resource.ProviderConfigKinds{
 		Config:    v1alpha1.ProviderConfigGroupVersionKind,
 		UsageList: v1alpha1.ProviderConfigUsageListGroupVersionKind,
+		Usage:     v1alpha1.ProviderConfigUsageGroupVersionKind,
 	}
 
 	r := providerconfig.NewReconciler(mgr, of,


### PR DESCRIPTION
  What happened

  - The panic is thrown at config.go:40 → providerconfig.NewReconciler, not anywhere in your scheme registration.
  - crossplane-runtime v2 added a Usage field to resource.ProviderConfigKinds and a new probe at reconciler.go:123
  (MustCreateObject(of.Usage, ...) to detect legacy provider-config-usage). Your config.go was written against the v1
  struct and only sets Config + UsageList.
  - of.Usage therefore stays the zero-value schema.GroupVersionKind{} — empty version — and MustCreateObject panics with
  no version "". The scheme name "pkg/runtime/scheme.go:111" is just apimachinery's auto-generated callsite name for
  the manager's scheme; a2 upgrade (be879d4).